### PR TITLE
shopに追加したカラムをビューに反映

### DIFF
--- a/app/controllers/admin/shops_controller.rb
+++ b/app/controllers/admin/shops_controller.rb
@@ -3,10 +3,22 @@ module Admin
     before_action :authenticate_admin! # 管理者認証を有効にする
 
     def index
-      @shops = Shop.all
+      @q = Shop.ransack(params[:q])
+      @is_admin = current_user.admin?
+      if params[:q].present?
+        @shops = @q.result(distinct: true)
+      else
+        @shops = Shop.all
+      end
+    
+      # タグで絞り込む
+      if params[:tag_name]
+        @shops = @shops.tagged_with(params[:tag_name])
+      end
     end
 
     def show
+      @is_admin = current_user.admin?
       @shop = Shop.find(params[:id])
       @tags = @shop.tag_counts_on(:tags)
     end
@@ -21,9 +33,11 @@ module Admin
 
     def create
       @shop = Shop.new(shop_params)
+      @shop.user_id = current_user.id
       if @shop.save
         redirect_to [:admin, @shop], notice: 'ショップの作成が完了しました'
       else
+        Rails.logger.error(@shop.errors.full_messages)
         render :new
       end
     end
@@ -46,7 +60,9 @@ module Admin
     private
 
     def shop_params
-      params.require(:shop).permit(:name, :address, :phone_number, :duel_space_available, :opening_hours, :tag_list,)
+      params.require(:shop).permit(:name, :address, :phone_number, :duel_space_available, :opening_hours, :tag_list, :latitude, :longitude, :user_id)
     end
+    
+
   end
 end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -7,6 +7,7 @@ class ShopsController < ApplicationController
 
   def index
     @q = Shop.ransack(params[:q])
+    @is_admin = current_user.admin?
     if params[:q].present?
       @shops = @q.result(distinct: true)
     else
@@ -23,6 +24,7 @@ class ShopsController < ApplicationController
   def show
     @shop = Shop.find(params[:id])
     @tags = @shop.tag_counts_on(:tags)
+    @is_admin = current_user.admin?
   end
 
   def favorites

--- a/app/views/admin/shops/_edit.html.erb
+++ b/app/views/admin/shops/_edit.html.erb
@@ -35,6 +35,22 @@
     <%= form.text_field :opening_hours, class: "form-control", required: true %>
   </div>
 
+  <div class="mb-3">
+    <%= form.label :公式HP, class: "form-label" %>
+    <%= form.text_field :official_hp, class: "form-control", required: true %>
+  </div>
+
+  <div class="mb-3">
+    <%= form.label :Twitter, class: "form-label" %>
+    <%= form.text_field :twitter, class: "form-control", required: true %>
+  </div>
+
+  <div class="mb-3">
+    <%= form.label :Instagram, class: "form-label" %>
+    <%= form.text_field :instagram, class: "form-control", required: true %>
+  </div>
+
+
   <!-- タグ付けフォームの追加 -->
   <div class="form-group form-group_tags">
     <%= form.label :tag_list, "タグ", class: "form-label" %>

--- a/app/views/admin/shops/_form.html.erb
+++ b/app/views/admin/shops/_form.html.erb
@@ -35,6 +35,27 @@
     <%= form.text_field :opening_hours, class: "form-control", required: true %>
   </div>
 
+
+
+
+  <div class="mb-3">
+    <%= form.label :公式HP, class: "form-label" %>
+    <%= form.text_field :official_hp, class: "form-control", required: true %>
+  </div>
+
+  <div class="mb-3">
+    <%= form.label :Twitter, class: "form-label" %>
+    <%= form.text_field :twitter, class: "form-control", required: true %>
+  </div>
+
+  <div class="mb-3">
+    <%= form.label :Instagram, class: "form-label" %>
+    <%= form.text_field :instagram, class: "form-control", required: true %>
+  </div>
+
+
+
+
   <!-- タグ付けフォームの追加 -->
   <div class="form-group form-group_tags">
     <%= form.label :tag_list, "タグ", class: "form-label" %>

--- a/app/views/admin/shops/index.html.erb
+++ b/app/views/admin/shops/index.html.erb
@@ -1,12 +1,13 @@
 <p style="color: green"><%= notice %></p>
 
 <h1>ショップ一覧</h1>
-<%= link_to "新規作成", new_admin_shop_path, class: "btn btn-primary" %>
+<% if @is_admin %>
+  <%= link_to "新規作成", new_admin_shop_path, class: "btn btn-primary" %>
+<% end %>
 
 <div id="shops">
   <% @shops.each do |shop| %>
-    <%= render shop %>
-
+    <%= render partial: "shop", locals: { shop: shop, is_admin: true } %>
   <% end %>
 </div>
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -30,6 +30,7 @@
         <% end %>
         <% if user_signed_in? %>
           <div class="text-end">
+            <%= link_to "ショップ一覧", shops_path, class: "btn btn-outline-light me-2" %>
             <%= link_to "ログアウト", destroy_user_session_path, class: "btn btn-outline-light me-2", method: :delete, data: {turbo_method: :delete } %>
             <%= link_to "マイページ", "/users/#{current_user.id}", class: "btn btn-warning" %>
           </div>

--- a/app/views/shops/_index.html.erb
+++ b/app/views/shops/_index.html.erb
@@ -5,27 +5,53 @@
         <strong>ショップ名:</strong>
         <%= shop.name %>
       </p>
+
       <p class="card-text">
         <strong>住所:</strong>
         <%= shop.address %>
       </p>
+
       <p class="card-text">
         <strong>電話番号:</strong>
         <%= shop.phone_number %>
       </p>
+
       <p class="card-text">
         <strong>デュエルスペース:</strong>
         <%= shop.duel_space_available %>
       </p>
+
       <p class="card-text">
         <strong>営業時間:</strong>
         <%= shop.opening_hours %>
       </p>
+
+      <p class="card-text">
+        <strong>公式HP:</strong>
+        <%= shop.official_hp %>
+      </p>
+
+      <p class="card-text">
+        <strong>Twitter:</strong>
+        <%= shop.twitter %>
+      </p>
+
+      <p class="card-text">
+        <strong>Instagram:</strong>
+        <%= shop.instagram %>
+      </p>
+
       <!-- タグ表示部分をパーシャルに移動 -->
       <%= render 'tags/tag_list', tag_list: shop.tag_list %>
     </div>
     <div class="card-footer d-flex justify-content-end">
-      <%= link_to "戻る", admin_shops_path, class: "btn btn-secondary me-2" %>
+      <% if @is_admin %>
+        <%= link_to "編集", edit_admin_shop_path(shop), class: "btn btn-primary me-2" %>
+        <%= link_to "戻る", shops_path, class: "btn btn-secondary me-2" %>
+        <%= button_to "削除", admin_shop_path(shop), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger" %>
+      <% else %>
+        <%= link_to "戻る", shops_path, class: "btn btn-secondary me-2" %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/shops/_shop.html.erb
+++ b/app/views/shops/_shop.html.erb
@@ -5,30 +5,58 @@
         <strong>ショップ名:</strong>
         <%= shop.name %>
       </p>
+
       <p class="card-text">
         <strong>住所:</strong>
         <%= shop.address %>
       </p>
+
       <p class="card-text">
         <strong>電話番号:</strong>
         <%= shop.phone_number %>
       </p>
+
       <p class="card-text">
         <strong>デュエルスペース:</strong>
         <%= shop.duel_space_available %>
       </p>
+
       <p class="card-text">
         <strong>営業時間:</strong>
         <%= shop.opening_hours %>
       </p>
+
+      <p class="card-text">
+        <strong>公式HP:</strong>
+        <%= shop.official_hp %>
+      </p>
+
+      <p class="card-text">
+        <strong>Twitter:</strong>
+        <%= shop.twitter %>
+      </p>
+
+      <p class="card-text">
+        <strong>Instagram:</strong>
+        <%= shop.instagram %>
+      </p>
+
       <!-- タグ表示部分をパーシャルに移動 -->
       <%= render 'tags/tag_list', tag_list: shop.tag_list %>
     </div>
-    <div class="card-footer text-end">
-      <%= link_to "詳細", shop_path(shop), class: "btn btn-primary" %>
+    <div class="card-footer d-flex justify-content-end">
+      <% if @is_admin %>
+        <%= link_to "編集", edit_admin_shop_path(shop), class: "btn btn-primary me-2" %>
+        <%= link_to "詳細", shop_path(shop), class: "btn btn-secondary me-2" %>
+        <%= button_to "削除", admin_shop_path(shop), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger" %>
+      <% else %>
+        <%= link_to "詳細", shop_path(shop), class: "btn btn-primary me-2" %>
+      <% end %>
     </div>
-    <div>
-      <%= render 'shops/favorite_buttons', { shop: shop } %>
-    </div>
+    <% unless @is_admin %>
+      <div>
+        <%= render 'shops/favorite_buttons', { shop: shop } %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -1,10 +1,13 @@
 <p style="color: green"><%= notice %></p>
 
 <h1>ショップ一覧</h1>
+<% if @is_admin %>
+  <%= link_to "新規作成", new_admin_shop_path, class: "btn btn-primary" %>
+<% end %>
 
 <div id="shops">
   <% @shops.each do |shop| %>
-    <%= render shop %>
+    <%= render partial: "shop", locals: { shop: shop, is_admin: false } %>
   <% end %>
 </div>
 

--- a/db/migrate/20240718021250_change_phone_number_to_string_in_shops.rb
+++ b/db/migrate/20240718021250_change_phone_number_to_string_in_shops.rb
@@ -1,0 +1,5 @@
+class ChangePhoneNumberToStringInShops < ActiveRecord::Migration[7.0]
+  def change
+    change_column :shops, :phone_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_12_064654) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_18_021250) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,7 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_12_064654) do
   create_table "shops", force: :cascade do |t|
     t.string "name"
     t.string "address"
-    t.integer "phone_number"
+    t.string "phone_number"
     t.integer "duel_space_available"
     t.string "opening_hours"
     t.datetime "created_at", null: false


### PR DESCRIPTION
ショップの新規作成と編集画面に以下の項目を追加
* 公式HP
* Twitter
* Instagram

一般ユーザーと管理者ユーザーでレンダリングする一覧画面と詳細画面のファイルを共通化